### PR TITLE
Fixed sql-service select, switched to promise-based mysql, added types to sql-service

### DIFF
--- a/src/models/sql-service.model.ts
+++ b/src/models/sql-service.model.ts
@@ -1,0 +1,21 @@
+interface Attribute {
+	field: string;
+	value: string | Array<string>;
+}
+
+interface Field {
+	name: string;
+	type: string;
+	nullable: boolean;
+	isPrimaryKey: boolean;
+	isForeignKey: boolean;
+	default: string | number;
+}
+
+interface SelectOptions {
+	fields?: string[];
+	constraints?: Attribute[];
+	compare?: "AND" | "OR";
+}
+
+export { Attribute, Field, SelectOptions };

--- a/src/routes/interface.ts
+++ b/src/routes/interface.ts
@@ -61,7 +61,7 @@ router.post(
 		const { table, fields = [], constraints = [] } = req.body;
 
 		try {
-			const result = await SQLService.select(table, fields, constraints);
+			const result = await SQLService.select(table, { fields, constraints });
 			return res.status(200).json({ result });
 		} catch (err) {
 			logger.error("SQLService.select failed. Error =", err);

--- a/src/utils/sql-util.ts
+++ b/src/utils/sql-util.ts
@@ -1,26 +1,11 @@
-interface SQLTableRow {
-	[x: string]: string;
-}
-
-interface SQLField {
-	Field: string;
-	Type: string;
-	Null: string;
-	Key: string;
-	Default: string | number;
-}
-
-interface SQLAttribute {
-	field: string;
-	value: string | Array<string>;
-}
+import { Attribute } from "../models/sql-service.model";
 
 class SQLUtil {
 	static format(value: string) {
 		return value.replace("'", "''");
 	}
 
-	static attrToString(attrArr: SQLAttribute[]) {
+	static attrToStringArr(attrArr: Attribute[]) {
 		return attrArr.map((field) => {
 			if (typeof field.value === "string")
 				return `${field.field}='${SQLUtil.format(field.value)}'`;
@@ -31,4 +16,4 @@ class SQLUtil {
 	}
 }
 
-export { SQLTableRow, SQLField, SQLAttribute, SQLUtil };
+export default SQLUtil;


### PR DESCRIPTION
- Changed sql-service select function signature to input options as an object for cleaner optional syntax
- Removed SQL types in place for MySQL2 types
- Rewired MySQL connection to sql-service query function. May need changes in the future.